### PR TITLE
Fix boost build time dependency on python3

### DIFF
--- a/recipes-support/boost/boost_%.bbappend
+++ b/recipes-support/boost/boost_%.bbappend
@@ -1,2 +1,2 @@
 PACKAGECONFIG_append = " python"
-PACKAGECONFIG[python] = "python3"
+PACKAGECONFIG[python] = "python3,,python3"


### PR DESCRIPTION
:Release Notes:
Fix boost build time dependency on python3

:Detailed Notes:
Fixes a build error on fast machines where boost would try to be built
before python3 finished building, causing a failure:

| In file included from ./boost/python/detail/prefix.hpp:13:0,
|                  from ./boost/python/numeric.hpp:8,
|                  from libs/python/src/numeric.cpp:6:
| ./boost/python/detail/wrap_python.hpp:50:23: fatal error: pyconfig.h:
  No such file or directory
|  # include <pyconfig.h>
|                        ^
| compilation terminated.

:Testing Performed:
Compiles boost well locally after cleanall-python3.

:QA Notes:

:Issues Addressed: