### PR TITLE
Fix duckietown-msgs build time dependency on ros2-visualization-msgs

### DIFF
--- a/recipes-duckietown2/duckietown-msgs/duckietown-msgs_git.bb
+++ b/recipes-duckietown2/duckietown-msgs/duckietown-msgs_git.bb
@@ -12,6 +12,7 @@ DEPENDS = " \
     ros2-std-msgs \
     ros2-geometry-msgs \
     ros2-sensor-msgs \
+    ros2-visualization-msgs \
 "
 
 RDEPENDS_${PN} = " \


### PR DESCRIPTION
:Release Notes:
Fix duckietown-msgs build time dependency on ros2-visualization-msgs

:Detailed Notes:
Fixes a build error where duckietown-msgs tries to be built
before ros2-visualization-msgs finished building, causing a failure
when configuring:

| CMake Error at CMakeLists.txt:21 (find_package):
|   By not providing "Findvisualization_msgs.cmake" in CMAKE_MODULE_PATH this
|   project has asked CMake to find a package configuration file provided by
|   "visualization_msgs", but CMake did not find one.
|
|   Could not find a package configuration file provided by
|   "visualization_msgs" with any of the following names:
|
|     visualization_msgsConfig.cmake
|     visualization_msgs-config.cmake
|
|   Add the installation prefix of "visualization_msgs" to CMAKE_PREFIX_PATH or
|   set "visualization_msgs_DIR" to a directory containing one of the above
|   files.  If "visualization_msgs" provides a separate development package or
|   SDK, be sure it has been installed.
|
|
| -- Configuring incomplete, errors occurred!

:Testing Performed:
Configures and builds duckietown-msgs well locally.

:QA Notes:

:Issues Addressed: