### PR TITLE
Add a 512MB swap file

### DIFF
--- a/recipes-core/webos-initscripts/webos-initscripts.bbappend
+++ b/recipes-core/webos-initscripts/webos-initscripts.bbappend
@@ -1,11 +1,22 @@
 # Copyright (c) 2018 LG Electronics, Inc.
 
-EXTENDPRAUTO_append = "ros2-lgsvlrpi1"
+EXTENDPRAUTO_append = "ros2-lgsvlrpi2"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI_append = " \
     file://0001-Set-default-resolution-to-800x480.patch \
     file://0002-Add-delay-between-LSM-startup-retries.patch \
+    file://0003-Configure-swapon-during-boot.patch \
+"
+
+do_install_append() {
+    dd if=/dev/zero of=swapfile.swap bs=1M count=512
+    mkswap -p 4096 swapfile.swap
+    install -vm 0600 swapfile.swap ${D}/
+}
+
+FILES_${PN} += " \
+    /swapfile.swap \
 "
 

--- a/recipes-core/webos-initscripts/webos-initscripts/0003-Configure-swapon-during-boot.patch
+++ b/recipes-core/webos-initscripts/webos-initscripts/0003-Configure-swapon-during-boot.patch
@@ -1,0 +1,36 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index adf717a..13e00b6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -132,6 +132,7 @@ if(${WEBOS_TARGET_DISTRO} STREQUAL "webos")
+         files/systemd/services/distro/${WEBOS_TARGET_DISTRO}/pm-log-daemon.service
+         files/systemd/services/distro/${WEBOS_TARGET_DISTRO}/pulseaudio.service
+         files/systemd/services/distro/${WEBOS_TARGET_DISTRO}/surface-manager.service
++        files/systemd/services/distro/${WEBOS_TARGET_DISTRO}/swapon.service
+         files/systemd/services/distro/${WEBOS_TARGET_DISTRO}/webapp-mgr.service
+         files/systemd/services/distro/${WEBOS_TARGET_DISTRO}/webos-bluetooth-service.service)
+ endif()
+diff --git a/files/systemd/services/distro/webos/swapon.service b/files/systemd/services/distro/webos/swapon.service
+new file mode 100644
+index 0000000..9ff7b03
+--- /dev/null
++++ b/files/systemd/services/distro/webos/swapon.service
+@@ -0,0 +1,8 @@
++[Unit]
++Description="Enables swap based on a .swap file"
++Before=surface-manager.service
++
++[Service]
++Type=simple
++ExecStart=/sbin/swapon /swapfile.swap
++Restart=no
+diff --git a/files/systemd/targets/default-webos.target b/files/systemd/targets/default-webos.target
+index 8ed0949..c0361bc 100644
+--- a/files/systemd/targets/default-webos.target
++++ b/files/systemd/targets/default-webos.target
+@@ -27,4 +27,5 @@ Wants=bootd.service \
+       sam.service \
+       surface-manager.service \
+       surface-manager-finalize.service \
++      swapon.service \
+       usbctrl.service

--- a/recipes-devtools/e2fsprogs/e2fsprogs/0001-Make-swap-files-contiguous.patch
+++ b/recipes-devtools/e2fsprogs/e2fsprogs/0001-Make-swap-files-contiguous.patch
@@ -1,0 +1,68 @@
+diff --git a/misc/create_inode.c b/misc/create_inode.c
+index c879a3ec..d01e5c9f 100644
+--- a/misc/create_inode.c
++++ b/misc/create_inode.c
+@@ -418,7 +418,7 @@ static errcode_t copy_file_range(ext2_filsys fs, int fd, ext2_file_t e2_file,
+ 			blen = fs->blocksize;
+ 			if (blen > got - bpos)
+ 				blen = got - bpos;
+-			if (memcmp(ptr, zerobuf, blen) == 0) {
++			if (zerobuf && memcmp(ptr, zerobuf, blen) == 0) {
+ 				ptr += blen;
+ 				continue;
+ 			}
+@@ -543,7 +543,7 @@ out:
+ }
+ 
+ static errcode_t copy_file(ext2_filsys fs, int fd, struct stat *statbuf,
+-			   ext2_ino_t ino)
++			   ext2_ino_t ino, int can_be_sparse)
+ {
+ 	ext2_file_t e2_file;
+ 	char *buf = NULL, *zerobuf = NULL;
+@@ -557,17 +557,19 @@ static errcode_t copy_file(ext2_filsys fs, int fd, struct stat *statbuf,
+ 	if (err)
+ 		goto out;
+ 
+-	err = ext2fs_get_memzero(fs->blocksize, &zerobuf);
+-	if (err)
+-		goto out;
++	if (can_be_sparse) {
++		err = ext2fs_get_memzero(fs->blocksize, &zerobuf);
++		if (err)
++			goto out;
+ 
+-	err = try_lseek_copy(fs, fd, statbuf, e2_file, buf, zerobuf);
+-	if (err != EXT2_ET_UNIMPLEMENTED)
+-		goto out;
++		err = try_lseek_copy(fs, fd, statbuf, e2_file, buf, zerobuf);
++		if (err != EXT2_ET_UNIMPLEMENTED)
++			goto out;
+ 
+-	err = try_fiemap_copy(fs, fd, e2_file, buf, zerobuf);
+-	if (err != EXT2_ET_UNIMPLEMENTED)
+-		goto out;
++		err = try_fiemap_copy(fs, fd, e2_file, buf, zerobuf);
++		if (err != EXT2_ET_UNIMPLEMENTED)
++			goto out;
++	}
+ 
+ 	err = copy_file_range(fs, fd, e2_file, 0, statbuf->st_size, buf,
+ 			      zerobuf);
+@@ -669,7 +671,15 @@ errcode_t do_write_internal(ext2_filsys fs, ext2_ino_t cwd, const char *src,
+ 			goto out;
+ 	}
+ 	if (LINUX_S_ISREG(inode.i_mode)) {
+-		retval = copy_file(fs, fd, &statbuf, newfile);
++		int can_be_sparse = 1;
++		const char *swap_ext = "swap";
++		char *ext = strrchr(src, '.');
++		if (ext != NULL
++                    && strncasecmp(ext + 1, swap_ext, sizeof(swap_ext)) == 0) {
++			/* .swap file can't be sparse or swapon fails */
++			can_be_sparse = 0;
++		}
++		retval = copy_file(fs, fd, &statbuf, newfile, can_be_sparse);
+ 		if (retval)
+ 			goto out;
+ 	}

--- a/recipes-devtools/e2fsprogs/e2fsprogs_1.43.bbappend
+++ b/recipes-devtools/e2fsprogs/e2fsprogs_1.43.bbappend
@@ -1,0 +1,9 @@
+# Copyright (c) 2018 LG Electronics, Inc.
+
+EXTENDPRAUTO_append = "ros2-lgsvlrpi1"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI_append = " \
+    file://0001-Make-swap-files-contiguous.patch \
+"


### PR DESCRIPTION
:Release Notes:
Add a 512MB swap file

:Detailed Notes:
Add a 512MB swap file providing more spare memory to run all ROS nodes
and web application in detriment of slightly wearing the flash if used
a lot. At the same time we're profiling the memory usage to make sure
there are no obvious leaks and there's no need to use swap at all.

:Testing Performed:
Works well when testing locally on robot.

:QA Notes:

:Issues Addressed: