### PR TITLE
fixes memory leaks in rclnodejs for subscribed messages

### DIFF
--- a/recipes-ros2/ros2-web-bridge/files/0002-fix-new-delete-mismatch.patch
+++ b/recipes-ros2/ros2-web-bridge/files/0002-fix-new-delete-mismatch.patch
@@ -1,0 +1,38 @@
+From 05cbb7a26a764a3c1ef3e3be61213a5fd740c6a1 Mon Sep 17 00:00:00 2001
+From: Martins Mozeiko <martins.mozeiko@lge.com>
+Date: Fri, 13 Jul 2018 16:45:52 -0700
+Subject: [PATCH] fix new/delete mismatch
+
+Memory allocated with new must be freed with delete, not free.
+---
+ src/executor.cpp     | 2 +-
+ src/rcl_bindings.cpp | 3 +--
+ 2 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/src/executor.cpp b/src/executor.cpp
+index b88d632..b1fc08e 100644
+--- a/src/executor.cpp
++++ b/src/executor.cpp
+@@ -62,7 +62,7 @@ void Executor::Stop() {
+                  // Important Notice:
+                  //  This might be called after Executor::~Executor()
+                  //  Don't free Executor::async_ in Executor's dtor
+-                 free(async);
++                 delete async;
+                  handle_closed = true;
+                });
+       while (!handle_closed)
+diff --git a/src/rcl_bindings.cpp b/src/rcl_bindings.cpp
+index 25c462e..3f90060 100644
+--- a/src/rcl_bindings.cpp
++++ b/src/rcl_bindings.cpp
+@@ -669,8 +669,7 @@ const rmw_qos_profile_t* GetQosProfileFromObject(v8::Local<v8::Object> object) {
+ }
+ 
+ rmw_qos_profile_t* GetQoSProfile(v8::Local<v8::Value> qos) {
+-  rmw_qos_profile_t* qos_profile =
+-      reinterpret_cast<rmw_qos_profile_t*>(malloc(sizeof(rmw_qos_profile_t)));
++  rmw_qos_profile_t* qos_profile = new rmw_qos_profile_t();
+ 
+   if (qos->IsString()) {
+     *qos_profile = *GetQoSProfileFromString(

--- a/recipes-ros2/ros2-web-bridge/files/0003-fix-memory-leak-in-subscription-messages.patch
+++ b/recipes-ros2/ros2-web-bridge/files/0003-fix-memory-leak-in-subscription-messages.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/subscription.js b/lib/subscription.js
+index d10bc8f..6e7277d 100644
+--- a/lib/subscription.js
++++ b/lib/subscription.js
+@@ -29,13 +29,13 @@
+     super(handle, typeClass, qos);
+     this._topic = topic;
+     this._callback = callback;
+-    this._message = new typeClass();
+   }
+ 
+   processResponse(msg) {
+-    this._message.deserialize(msg);
++    let message = new this._typeClass();
++    message.deserialize(msg);
+     debug(`Message of topic ${this._topic} received.`);
+-    this._callback(toPlainObject(this._message));
++    this._callback(toPlainObject(message));
+   }
+ 
+   static createSubscription(nodeHandle, typeClass, topic, callback, qos) {

--- a/recipes-ros2/ros2-web-bridge/ros2-web-bridge.bb
+++ b/recipes-ros2/ros2-web-bridge/ros2-web-bridge.bb
@@ -54,6 +54,12 @@ do_install () {
     # Compile and install
     ${STAGING_BINDIR_NATIVE}/npm install --production --unsafe-perm --arch=${targetArch} --target-arch=${targetArch} --verbose -g --prefix=${D}${prefix}
 
+    # patch rclnodejs
+    cd ${D}${prefix}/lib/node_modules/ros2-web-bridge/node_modules/rclnodejs
+    patch -p 1 -i "${THISDIR}/files/0002-fix-new-delete-mismatch.patch"
+    patch -p 1 -i "${THISDIR}/files/0003-fix-memory-leak-in-subscription-messages.patch"
+    ${STAGING_BINDIR_NATIVE}/npm rebuild --production --unsafe-perm --arch=${targetArch} --target-arch=${targetArch} --verbose -g --prefix=${D}${prefix}
+
     rm -fr ${D}${libdir}/node_modules/ros2-web-bridge/npm-pack.sh
     rm -fr ${D}${libdir}/node_modules/ros2-web-bridge/node_modules/rclnodejs/test/
     rm -fr ${D}${libdir}/node_modules/ros2-web-bridge/node_modules/rclnodejs/scripts


### PR DESCRIPTION
rclnodejs was leaking memory due to reusing message object for incoming subscription messages. This patch allocates new message object for every new message incoming. See https://github.com/RobotWebTools/rclnodejs/issues/381 for details.

Also includes patch from https://github.com/RobotWebTools/rclnodejs/pull/377