### PR TITLE
Fix boost build time dependency on python

### DIFF
--- a/recipes-support/boost/boost_%.bbappend
+++ b/recipes-support/boost/boost_%.bbappend
@@ -1,2 +1,0 @@
-PACKAGECONFIG_append = " python"
-PACKAGECONFIG[python] = "python3,,python3"


### PR DESCRIPTION
Drop the bbappend for boost, which fixes a build error on fast machines
where boost would try to be built before python finished building,
causing the failure:

    | In file included from ./boost/python/detail/prefix.hpp:13:0,
    |                  from ./boost/python/numeric.hpp:8,
    |                  from libs/python/src/numeric.cpp:6:
    | ./boost/python/detail/wrap_python.hpp:50:23: fatal error: pyconfig.h:
      No such file or directory
    |  # include <pyconfig.h>
    |                        ^
    | compilation terminated.

Confirm python and python3 dependencies are present when building boost
by issuing:

   bitbake -c cleanall python python3 boost
   bitbake -c cleanall python-native python3-native boost-native
   bitbake boost boost-native