### PR TITLE
Add missing lifecycle-msgs dependencies

### DIFF
--- a/recipes-ros2/rcl-interfaces/lifecycle-msgs_git.bbappend
+++ b/recipes-ros2/rcl-interfaces/lifecycle-msgs_git.bbappend
@@ -1,0 +1,11 @@
+# Copyright (c) 2019 LG Electronics, Inc.
+
+EXTENDPRAUTO_append = "ros2-lgsvl1"
+
+# Remove this file when upstream recipe is updated.
+
+DEPENDS_append = " \
+    rmw-implementation-cmake \
+    rosidl-typesupport-c \
+    rosidl-typesupport-cpp \
+"


### PR DESCRIPTION
Create a .bbappend in this layer to add dependencies missing from the
upstream recipe for lifecycle-msgs.

Revert this commit once the upstream recipe is fixed.